### PR TITLE
enable a dirty mkdocs build

### DIFF
--- a/EngineBay.DocumentationPortal/EngineBay.DocumentationPortal.csproj
+++ b/EngineBay.DocumentationPortal/EngineBay.DocumentationPortal.csproj
@@ -74,9 +74,9 @@
             <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
         </Exec>
         <Exec Command="python3 --version" ContinueOnError="true">
-            <Output TaskParameter="ExitCode" PropertyName="ErrorCode3" />
+            <Output TaskParameter="ExitCode" PropertyName="ErrorCodePy3" />
         </Exec>
-        <Error Condition="'$(ErrorCode)' != '0' AND '$(ErrorCode3)' != '0'"
+        <Error Condition="'$(ErrorCode)' != '0' AND '$(ErrorCodePy3)' != '0'"
             Text="Python is required to build and run this project. To continue, please install Python from https://www.python.org/, and then restart your command prompt or IDE." />
     </Target>
 
@@ -97,5 +97,8 @@
         Condition="'$(ASPNETCORE_ENVIRONMENT)' != 'Development'">
         <Exec WorkingDirectory="$(SpaRoot)" Command="mkdocs build --strict" />
     </Target>
-
+    <Target Name="MKDocsBuild" AfterTargets="Build"
+        Condition="'$(ASPNETCORE_ENVIRONMENT)' == 'Development'">
+        <Exec WorkingDirectory="$(SpaRoot)" Command="mkdocs build --dirty" />
+    </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ This is the documentation repository for Engine Bay, it uses [mkdocs](https://gi
 Please ensure that you have the following installed
 
 - [Node](https://nodejs.org/)
+    ```bash
+    node --version
+    ```
 - [Python](https://www.python.org/)
-- [Pip](https://pip.pypa.io/en/stable/installation/)
+    ```bash
+    python --version
+    python3 --version
+    ```
+- [Pip](https://pip.pypa.io/en/stable/installation/). Pip should be installed with Python, check using the following command
+    ```bash
+    pip3 --version
+    ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,27 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/1b17960d6d125f22eff5/test_coverage)](https://codeclimate.com/github/engine-bay/documentation-portal/test_coverage)
 
 DocumentationPortal module for EngineBay published to [EngineBay.DocumentationPortal](https://www.nuget.org/packages/EngineBay.DocumentationPortal/) on NuGet.
+
+## About
+
+This is the documentation repository for Engine Bay, it uses [mkdocs](https://github.com/mkdocs/mkdocs) to generate a static site from markdown files. Documentation can be added as markdown files in the [docs](./EngineBay.DocumentationPortal/DocumentationPortal/docs/) folder.
+
+## Prerequisites
+
+Please ensure that you have the following installed
+
+- [Node](https://nodejs.org/)
+- [Python](https://www.python.org/)
+- [Pip](https://pip.pypa.io/en/stable/installation/)
+
+## Usage
+
+The `mkdocs build` command will be executed when we build this [project](./EngineBay.DocumentationPortal/EngineBay.DocumentationPortal.csproj) using `dotnet build`.
+
+In the development environment mkdocs will build with the `--dirty` flag, this will give the fastest build times but could have issues with links etc. To fix these issues either build using `mkdocs build --strict` or by using the [build script](./EngineBay.DocumentationPortal/generate-docs.sh).
+
+In the pipelines we wil do the longer full build.
+
+## Deploying the static site
+
+TBC - This will be hosted as github pages.


### PR DESCRIPTION
mkdocs needs to build at least once for the app to run. This enables a dirty build, which will be faster from the second build onwards as it does not delete files from the output directory.
A clean build can be forced on using the cli or generate-docs.sh